### PR TITLE
Revert "Bump prettier from 2.8.8 to 3.1.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "chai-as-promised": "^7.1.1",
         "hardhat": "^2.19.0",
         "mocha": "^10.2.0",
-        "prettier": "^3.1.0",
+        "prettier": "^2.8.8",
         "ts-node": "^10.9.1",
         "tslint": "^6.1.3",
         "tslint-config-prettier": "^1.18.0",
@@ -3875,15 +3875,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
-      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
-        "prettier": "bin/prettier.cjs"
+        "prettier": "bin-prettier.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=10.13.0"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
@@ -7650,9 +7650,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.0.tgz",
-      "integrity": "sha512-TQLvXjq5IAibjh8EpBIkNKxO749UEWABoiIZehEPiY4GNpVdhaFKqSTu+QrlU6D2dPAfubRmtJTi4K4YkQ5eXw==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true
     },
     "queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "chai-as-promised": "^7.1.1",
     "hardhat": "^2.19.0",
     "mocha": "^10.2.0",
-    "prettier": "^3.1.0",
+    "prettier": "^2.8.8",
     "ts-node": "^10.9.1",
     "tslint": "^6.1.3",
     "tslint-config-prettier": "^1.18.0",


### PR DESCRIPTION
Prettier v2 is required as a peer dep, so the [publish failed](https://github.com/tablelandnetwork/hardhat-tableland/actions/runs/6934346606/job/18862248792).